### PR TITLE
Fix link to the Git learning resource on Microsoft

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ I'm using some emoticons to give you more information on these links.
 * 🌍 [Learn Git on CodeCademy](https://www.codecademy.com/learn/learn-git) 💰🆓 🔝
 * [Git-it is a (Mac, Win, Linux) Desktop App for Learning Git and GitHub](https://github.com/jlord/git-it-electron) 🆓 🔝
 * [Learn Git Branching – Educational challenges](https://learngitbranching.js.org/) 🆓
-* [Learn Git by Microsoft](https://www.visualstudio.com/learn-git/) 🆓
+* [Introduction to version control with Git - Microsoft Learn](https://docs.microsoft.com/en-gb/learn/paths/intro-to-vc-git/) 🆓
 * [Git-it – Learn Git in a real terminal](http://jlord.us/git-it/) 🆓
 * [Git CheatSheet](http://www.ndpsoftware.com/git-cheatsheet.html) 🆓
 * [Git Essential Training - Lynda](https://www.lynda.com/Git-tutorials/Git-Essential-Training/100222-2.html) 💰 📹


### PR DESCRIPTION
This Pull Request fixes the outdated link to the Git learning resource on Microsoft. The learning resources are now hosted on Microsoft Learn site.